### PR TITLE
Arsenal - Fix: add `{}` to items.

### DIFF
--- a/.hemtt/missions/Arsenal.Altis/cvo_arsenal_kits.hpp
+++ b/.hemtt/missions/Arsenal.Altis/cvo_arsenal_kits.hpp
@@ -17,7 +17,7 @@
 *   condition            <STRING>   Code as String, needs to return boolean.                        <Default: ""> Empty String will skip check.             Example: condition = "missionNamespace getVariable ["cvo_nightFight", false]";
 *   code                 <STRING>   Code as String, needs to return array of classnames.            <Default: ""> Empty String will skip execution.         Example: code = "if (1 == 1) then { ["ace_banana"] } else { [] }";
 *   items <CLASS with SUBCLASSES>                                                                                                                           Example: class items {
-*   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                   |     class ace_banana;
+*   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                   |     class ace_banana {};
 *   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                   | };
 *
 */
@@ -33,9 +33,9 @@ class cvo_arsenal_kits
     // Base Kit - AK47 for everyone!
     class AK74: Base {
         class items {
-            class ACE_bodyBag;
-            class ACE_bodyBag_blue;
-            class ACE_bodyBag_white;
+            class ACE_bodyBag {};
+            class ACE_bodyBag_blue {};
+            class ACE_bodyBag_white {};
         };
     };
     
@@ -43,7 +43,7 @@ class cvo_arsenal_kits
     class BarrelsForMG: Base {
         role = "Machinegunner";
         class items {
-            class ACE_personalAidKit;
+            class ACE_personalAidKit {};
         };
     };
 
@@ -51,8 +51,8 @@ class cvo_arsenal_kits
     class something: Base {
         id64 = "123123";
         class items {
-            class ace_banana;
-            class ACE_suture;
+            class ace_banana {};
+            class ACE_suture {};
         };
     };
 };

--- a/addons/arsenal/kits_base.hpp
+++ b/addons/arsenal/kits_base.hpp
@@ -1,57 +1,57 @@
 // Base Kit - Accessible for Everyone
 class BaseKit_Medical: Base {
     class items {
-        class ACE_packingBandage;
-        class ACE_fieldDressing;
+        class ACE_packingBandage {};
+        class ACE_fieldDressing {};
 
-        class ACE_tourniquet;
-        class ACE_splint;
+        class ACE_tourniquet {};
+        class ACE_splint {};
 
-        class ACE_painkillers;
+        class ACE_painkillers {};
         
-        class ACE_epinephrine;
+        class ACE_epinephrine {};
 
-        class ACE_salineIV;
-        class ACE_salineIV_500;
-        class ACE_salineIV_250;
+        class ACE_salineIV {};
+        class ACE_salineIV_500 {};
+        class ACE_salineIV_250 {};
 
-        class ACE_personalAidKit;
+        class ACE_personalAidKit {};
 
-        class ACE_bodyBag;
+        class ACE_bodyBag {};
     };
 };
 
 class BaseKit_Utility: Base {
     class items {
-        class ace_marker_flags_red;
-        class ace_marker_flags_green;
+        class ace_marker_flags_red {};
+        class ace_marker_flags_green {};
 
-        class ACE_EntrenchingTool;
+        class ACE_EntrenchingTool {};
 
-        class ACE_SpraypaintGreen;
-        class ACE_SpraypaintRed;
+        class ACE_SpraypaintGreen {};
+        class ACE_SpraypaintRed {};
 
-        class ACE_PlottingBoard;
+        class ACE_PlottingBoard {};
 
-        class ACE_CableTie;
-        class acex_intelitems_notepad;
+        class ACE_CableTie {};
+        class acex_intelitems_notepad {};
     };
 };
 
 class BaseKit_Orientation: Base {
     class items {
-        class ACE_DAGR;
+        class ACE_DAGR {};
 
-        class ItemMap;
-        class ItemWatch;
+        class ItemMap {};
+        class ItemWatch {};
 
-        class ItemCompass;
-        class ACE_MapTools;
+        class ItemCompass {};
+        class ACE_MapTools {};
 
-        class ACE_Flashlight_KSF1;
-        class ACE_Chemlight_Shield;
+        class ACE_Flashlight_KSF1 {};
+        class ACE_Chemlight_Shield {};
 
-        class Chemlight_yellow;
+        class Chemlight_yellow {};
     };
 };
 
@@ -60,24 +60,24 @@ class BaseKit_Orientation: Base {
 class ACE_Hearing_Enabled: Base {
     condition = "missionNamespace getVariable ['ace_hearing_enableCombatdeafness', true]"; // Find right Setting Variable
     class items {
-        class ACE_EarPlugs;
+        class ACE_EarPlugs {};
     };
 };
 
 class ACE_Overheating_Enabled: Base {
     condition = "missionNamespace getVariable ['ace_overheating_enabled', true]";
     class items {
-        class ACE_WaterBottle;
-        class ACE_Canteen;
+        class ACE_WaterBottle {};
+        class ACE_Canteen {};
     };
 };
 
 class ACE_FieldRations_Enabled: Base {
     condition = "missionNamespace getVariable ['ace_field_rations_enabled', true]";
     class items {
-        class ACE_WaterBottle;
-        class ACE_Canteen;
-        class ACE_Humanitarian_Ration;
+        class ACE_WaterBottle {};
+        class ACE_Canteen {};
+        class ACE_Humanitarian_Ration {};
     };
 };
 
@@ -86,15 +86,15 @@ class ACE_FieldRations_Enabled: Base {
 class ImmersionCigs_Loaded: Base {
     addon_dependency = "cigs_core"; // Find right Addon to be checked
     class items {
-        class cigs_lighter;
-        class cigs_matches;
-        class cigs_voron_cigpack;
+        class cigs_lighter {};
+        class cigs_matches {};
+        class cigs_voron_cigpack {};
     };
 };
 
 class GreenMag_Loaded: Base {
     addon_dependency = "greenmag_main"; // Find right Addon to be checked
     class items {
-        class greenmag_item_speedloader;
+        class greenmag_item_speedloader {};
     };
 };

--- a/addons/arsenal/kits_personal.hpp
+++ b/addons/arsenal/kits_personal.hpp
@@ -1,9 +1,9 @@
 class EDITOR_DEBUG: Base {
     id64 = "_SP_PLAYER_";
     class items {
-        class ACE_Banana;
-        class ACE_SpraypaintBlack;
-        class ACE_SpraypaintWhite;
+        class ACE_Banana {};
+        class ACE_SpraypaintBlack {};
+        class ACE_SpraypaintWhite {};
     };
     code = "systemChat 'CVO_A_Playerkit test Successful - ACE_Sandbag_empty Given'; 'ACE_Sandbag_empty'";
 };
@@ -11,16 +11,16 @@ class EDITOR_DEBUG: Base {
 class OverlordZorn: Base {
     id64 = "76561197970306509";
     class items {
-        class G_Spectacles_Tinted;
-        class G_Balaclava_blk;
-        class H_Beret_blk;
+        class G_Spectacles_Tinted {};
+        class G_Balaclava_blk {};
+        class H_Beret_blk {};
 
-        class ACE_SpraypaintBlack;
-        class ACE_SpraypaintWhite;
+        class ACE_SpraypaintBlack {};
+        class ACE_SpraypaintWhite {};
 
-        class ACE_wirecutter;
+        class ACE_wirecutter {};
 
-        class cvo_LegStrapBag_black;
-        class cvo_Kitbag_blk;
+        class cvo_LegStrapBag_black {};
+        class cvo_Kitbag_blk {};
     };
 };

--- a/addons/arsenal/kits_role.hpp
+++ b/addons/arsenal/kits_role.hpp
@@ -2,21 +2,21 @@
 class BaseRoleKit_Medic: Base {
     role = "Medic";
     class items {
-        class ACE_quikclot;
-        class ACE_elasticBandage;
+        class ACE_quikclot {};
+        class ACE_elasticBandage {};
         
-        class ACE_adenosine;
-        class ACE_morphine;
+        class ACE_adenosine {};
+        class ACE_morphine {};
 
-        class ACE_plasmaIV;
-        class ACE_plasmaIV_500;
-        class ACE_plasmaIV_250;
+        class ACE_plasmaIV {};
+        class ACE_plasmaIV_500 {};
+        class ACE_plasmaIV_250 {};
 
-        class ACE_bloodIV;
-        class ACE_bloodIV_500;
-        class ACE_bloodIV_250;
+        class ACE_bloodIV {};
+        class ACE_bloodIV_500 {};
+        class ACE_bloodIV_250 {};
 
-        class ACE_surgicalKit;
+        class ACE_surgicalKit {};
     };
 };
  
@@ -24,7 +24,7 @@ class BaseRoleKit_Medic_suture: Base {
     role = "medic";
     condition = "missionNamespace getVariable ['ace_medical_treatment_consumeSurgicalKit',0] == 2";
     class items {
-        class ACE_suture;
+        class ACE_suture {};
     };
 };
 
@@ -39,15 +39,15 @@ class BaseRoleKit_Doctor: Base {
 class BaseRoleKit_Engineer: Base {
     role = "Engineer";
     class items {
-        class ACE_wirecutter;
-        class ACE_ToolKit;
+        class ACE_wirecutter {};
+        class ACE_ToolKit {};
     };
 };
 
 class BaseRoleKit_AdvEngineer: Base {
     role = "AdvEngineer";
     class items {
-        class ACE_Fortify;
+        class ACE_Fortify {};
     };
 };
 
@@ -56,19 +56,19 @@ class BaseRoleKit_AdvEngineer: Base {
 class BaseRoleKit_ExplosiveSpecialist: Base {
     role = "ExplosiveSpecialist";
     class items {
-        class ACE_VMH3;
-        class ACE_VMM3;
-        class ACE_DefusalKit;
+        class ACE_VMH3 {};
+        class ACE_VMM3 {};
+        class ACE_DefusalKit {};
 
-        class DemoCharge_Remote_Mag;
-        class SatchelCharge_Remote_Mag;
+        class DemoCharge_Remote_Mag {};
+        class SatchelCharge_Remote_Mag {};
     };
 };
 class BaseRoleKit_ExplosiveSpecialist_IEDD: Base {
     addon_dependency = "iedd_main";
     role = "ExplosiveSpecialist";
     class items {
-        class iedd_item_notebook;
+        class iedd_item_notebook {};
     };
 };
 
@@ -76,8 +76,8 @@ class BaseRoleKit_ExplosiveSpecialist_convertFuses: Base {
     role = "ExplosiveSpecialist";
     condition = "missionNamespace getvariable ['ace_grenades_convertExplosives', false]";
     class items {
-        class ACE_DemoCharge_Remote_Mag_Throwable;
-        class ACE_SatchelCharge_Remote_Mag_Throwable;
+        class ACE_DemoCharge_Remote_Mag_Throwable {};
+        class ACE_SatchelCharge_Remote_Mag_Throwable {};
     };
 };
 
@@ -86,7 +86,7 @@ class BaseRoleKit_ExplosiveSpecialist_convertFuses: Base {
 class BaseRoleKit_Machinegunner: Base {
     role = "Machinegunner";
     class items {
-        class ACE_SpareBarrel;
+        class ACE_SpareBarrel {};
     };
 };
 
@@ -95,9 +95,9 @@ class BaseRoleKit_Machinegunner: Base {
 class BaseRoleKit_Marksman: Base {
     role = "Marksman";
     class items {
-        class ACE_Tripod;
-        class ACE_RangeCard;
-        class Rangefinder;
+        class ACE_Tripod {};
+        class ACE_RangeCard {};
+        class Rangefinder {};
     };
 };
 
@@ -106,11 +106,11 @@ class BaseRoleKit_EWSpecialist: Base {
     role = "EWSpecialist";
     class items {
         //spectrum device
-        class hgun_esd_01_F;
-        class acc_esd_01_flashlight;
-        class muzzle_antenna_01_f;
-        class muzzle_antenna_03_f;
-        class muzzle_antenna_02_f;
+        class hgun_esd_01_F {};
+        class acc_esd_01_flashlight {};
+        class muzzle_antenna_01_f {};
+        class muzzle_antenna_03_f {};
+        class muzzle_antenna_02_f {};
     };
 };
 
@@ -119,10 +119,10 @@ class BaseRoleKit_EWSpecialist: Base {
 class BaseRoleKit_RTO: Base {
     role = "RTO";
     class items {
-        class ACRE_PRC77;
-        class ACRE_VHF30108SPIKE; 
-        class ACRE_VHF30108; 
-        class ACRE_VHF30108MAST;
+        class ACRE_PRC77 {};
+        class ACRE_VHF30108SPIKE {}; 
+        class ACRE_VHF30108 {}; 
+        class ACRE_VHF30108MAST {};
     };
 };
 
@@ -130,7 +130,7 @@ class BaseRoleKit_RTO: Base {
 class BaseRoleKit_UAV: Base {
     role = "UAV";
     class items {
-        class ACE_UAVBattery;
+        class ACE_UAVBattery {};
     };
     code = "switch (str side ACE_player) do {
         case 'WEST': { 'B_UavTerminal' };


### PR DESCRIPTION
Arma 3 2.20 will throw a hint when a class is declared but not defined, so we have to add this to not spam the rpt with shizzle.