### PR TITLE
CSC - Improvement: Disable isBusy feature when requested by Zeus for base_airDrop

### DIFF
--- a/addons/csc/functions/accessPoint/fn_createAccessPointZeus.sqf
+++ b/addons/csc/functions/accessPoint/fn_createAccessPointZeus.sqf
@@ -22,7 +22,8 @@ private _destinations = ["ZEUS", "DESTINATIONS"] call FUNC(getDefaultPresets);
 private _accessPoint = createHashMapFromArray [
     [QGVAR(crates),         _crates        ],
     [QGVAR(destinations),   _destinations  ],
-    [QGVAR(delivery_modes), _delivery_modes]
+    [QGVAR(delivery_modes), _delivery_modes],
+    ["isZeus",              true           ]
 ];
 
 private _conditionCode = { true };

--- a/addons/csc/functions/delivery/fn_base_airdrop.sqf
+++ b/addons/csc/functions/delivery/fn_base_airdrop.sqf
@@ -122,7 +122,10 @@ _wpEnd setWaypointStatements ["true", "{deleteVehicle _x} forEach ([vehicle this
     }
 ] call CBA_fnc_waitUntilAndExecute;
 
-// Declare the mode as isBusy
+
+
+// Declare the mode as isBusy if not requested by Zeus
+if !(_request getOrDefault ["isZeus", false]) exitWith {};
 private _isBusyVarName = format ["%1_isBusy", _request get "delivery_mode"];
 
 diag_log format ['[CVO](debug)(fn_base_airdrop) _isBusyVarName: %1', _isBusyVarName];

--- a/addons/csc/functions/ui/fn_openDialog.sqf
+++ b/addons/csc/functions/ui/fn_openDialog.sqf
@@ -24,6 +24,7 @@ _params params [["_accessPoint", createHashMap]];
 private _crates = _accessPoint getOrDefault [QGVAR(crates), []];
 private _destinations = _accessPoint getOrDefault [QGVAR(destinations), []];
 private _delivery_modes = _accessPoint getOrDefault [QGVAR(delivery_modes), []];
+private _isZeus = _accessPoint getOrDefault ["isZeus", false];
 
 
 
@@ -33,7 +34,7 @@ private _display = createDialog [QGVAR(request), true];
 
 _display setVariable ["requester", _player];
 _display setVariable ["target", _target];
-
+_display setVariable ["isZeus", _isZeus];
 
 _display setVariable [
     QGVAR(crates),

--- a/addons/csc/functions/ui/fn_ui_onUnload.sqf
+++ b/addons/csc/functions/ui/fn_ui_onUnload.sqf
@@ -48,7 +48,8 @@ private _request = createHashMapFromArray [
     [ "requester",     _display getVariable "requester" ],
     [ "target",        _display getVariable "target" ],
     [ "destination",   _display getVariable QGVAR(destination) ],
-    [ "delivery_mode", _display getVariable QGVAR(delivery_mode) ]
+    [ "delivery_mode", _display getVariable QGVAR(delivery_mode) ],
+    [ "isZeus",        _display getVariable "isZeus" ]
 ];
 
 ZRN_LOG_MSG_1(REQUEST Established. Handling Destination next,_request);

--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -1,7 +1,7 @@
 #define MAJOR 1
 #define MINOR 8
 #define PATCH 0
-#define BUILD 585
+#define BUILD 586
 
 
 // #define VERSION MACROS


### PR DESCRIPTION
Introduces an 'isZeus' flag to access point creation, dialog UI, and request handling to distinguish Zeus-initiated requests. Updates airdrop logic to skip isBusy mode for Zeus requests. Increments script version build number.